### PR TITLE
push gensh change

### DIFF
--- a/src/ublu/util/GenSh.java
+++ b/src/ublu/util/GenSh.java
@@ -342,6 +342,10 @@ public class GenSh {
 
     private String genInvocation() {
         StringBuilder sb = new StringBuilder("# Invocation\n");
+        // In case of relative import (especially for portable gensh scripts,
+        // which may not be run on the machine where they are generated, or in
+        // the same path), cd to the gensh script directory first.
+        sb.append("cd \"$(dirname \"$0\")\"\n");
         sb.append("java -jar ")
                 .append(fqJarPath)
                 .append(' ')


### PR DESCRIPTION
There can be problems when using relative include paths for gensh scripts.  This is an issue when gensh scripts are distributed in the hopes of being portable (ie. the absolute path to the ublu file can not be predicted nor enforced).  This will cd to the gensh script's location before running ublu, so absolute paths shouldn't be affected, and relative paths will behave more predictably.