### PR TITLE
Includepath

### DIFF
--- a/CHANGES.TXT
+++ b/CHANGES.TXT
@@ -19,6 +19,7 @@ System
 Commands
 * general
 	* more cleanup
+	* ublu.includepath property management
 * individual commands
 	* calljava
 		* properly deals with interfaces
@@ -40,6 +41,9 @@ Commands
 	* gensh
 		* -strictPosix
 		* gensh was generating bad documentary headers when passed plainwords.
+        * -includepath
+    * include
+        * relative includes try to take ublu.includepath property into account
     * record
     	* -create
     	* -getcontents

--- a/src/ublu/command/CmdGenSh.java
+++ b/src/ublu/command/CmdGenSh.java
@@ -47,7 +47,7 @@ public class CmdGenSh extends Command {
 
     {
         setNameAndDescription("gensh",
-                "/5+ [-to datasink] [-strictPosix] [[-path fullyqualifiedjarpath] [-includepath searchpath] [-opt optchar assignment_name tuplename ${ description }$ ..] [-optr optchar assignment_name tuplename ${ description }$] [-optx optchar multiple_assignment_name tuplename ${ description }$ ..]] ~@${scriptname} ~@${includename}$ ~@${ functionCall ( @a @b ... ) }$ : generate launcher shell script");
+                "/5+ [-to datasink] [-strictPosix] [[-path fullyqualifiedjarpath] [-includepath ~@${searchpath}] [-opt optchar assignment_name tuplename ${ description }$ ..] [-optr optchar assignment_name tuplename ${ description }$] [-optx optchar multiple_assignment_name tuplename ${ description }$ ..]] ~@${scriptname} ~@${includename}$ ~@${ functionCall ( @a @b ... ) }$ : generate launcher shell script");
     }
 
     /**
@@ -91,7 +91,7 @@ public class CmdGenSh extends Command {
                     genSh.accumulateCommand(genSh.getFqJarPath());
                     break;
                 case "-includepath":
-                    genSh.setIncludePath(argArray.next());
+                    genSh.setIncludePath(argArray.nextMaybeQuotationTuplePopString());
                     genSh.accumulateCommand(genSh.getIncludePath());
                     break;
                 default:

--- a/src/ublu/command/CmdGenSh.java
+++ b/src/ublu/command/CmdGenSh.java
@@ -47,7 +47,7 @@ public class CmdGenSh extends Command {
 
     {
         setNameAndDescription("gensh",
-                "/5+ [-to datasink] [-strictPosix] [[-path fullyqualifiedjarpath] [-opt optchar assignment_name tuplename ${ description }$ ..] [-optr optchar assignment_name tuplename ${ description }$] [-optx optchar multiple_assignment_name tuplename ${ description }$ ..]] ~@${scriptname} ~@${includename}$ ~@${ functionCall ( @a @b ... ) }$ : generate launcher shell script");
+                "/5+ [-to datasink] [-strictPosix] [[-path fullyqualifiedjarpath] [-includepath searchpath] [-opt optchar assignment_name tuplename ${ description }$ ..] [-optr optchar assignment_name tuplename ${ description }$] [-optx optchar multiple_assignment_name tuplename ${ description }$ ..]] ~@${scriptname} ~@${includename}$ ~@${ functionCall ( @a @b ... ) }$ : generate launcher shell script");
     }
 
     /**
@@ -89,6 +89,10 @@ public class CmdGenSh extends Command {
                 case "-path":
                     genSh.setFqJarPath(argArray.next());
                     genSh.accumulateCommand(genSh.getFqJarPath());
+                    break;
+                case "-includepath":
+                    genSh.setIncludePath(argArray.next());
+                    genSh.accumulateCommand(genSh.getIncludePath());
                     break;
                 default:
                     unknownDashCommand(dashCommand);

--- a/src/ublu/util/GenSh.java
+++ b/src/ublu/util/GenSh.java
@@ -338,10 +338,9 @@ public class GenSh {
     }
 
     private String genScriptDir() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("# scriptdir generation for use in -includepath\n")
-            .append("SCRIPTDIR=\"$(CDPATH= cd \"$(dirname \"$0\")\" && pwd)\"\n");
-        return sb.toString();
+        // SCRIPTDIR variable generation, for use in ublu.includepath; the cd
+        // && pwd pair is used because a simple dirname fails on relative calls
+        return "SCRIPTDIR=$(CDPATH= cd \"$(dirname \"$0\")\" && pwd)\n";
     }
 
     private String genOptionsString() {

--- a/src/ublu/util/GenSh.java
+++ b/src/ublu/util/GenSh.java
@@ -46,6 +46,7 @@ public class GenSh {
     private String functionInvocation;
     private String scriptName;
     private String includeName;
+    private String includePath;
     private StringBuffer accumulatedCommand = new StringBuffer("gensh");
     private String dateGenerated = Calendar.getInstance().getTime().toString();
     private String generatingUser = Ublu.getUser();
@@ -125,6 +126,7 @@ public class GenSh {
     public GenSh() {
         this.optionArrayList = new OptionArrayList();
         fqJarPath = DEFAULT_FQJARPATH;
+        includePath = "";
     }
 
     /**
@@ -204,6 +206,24 @@ public class GenSh {
      */
     public void setIncludeName(String includeName) {
         this.includeName = includeName;
+    }
+
+    /**
+     * Get the include path for the gensh script, for relative imports
+     *
+     * @return the include path to find the script
+     */
+    public String getIncludePath() {
+        return includePath;
+    }
+
+    /**
+     * Set the include path for the gensh script, for relative imports
+     *
+     * @param includePath the include path, to find the script
+     */
+    public void setIncludePath(String includePath) {
+        this.includePath = includePath;
     }
 
     /**
@@ -317,6 +337,13 @@ public class GenSh {
         return sb.toString();
     }
 
+    private String genScriptDir() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("# scriptdir generation for use in -includepath\n")
+            .append("SCRIPTDIR=\"$(CDPATH= cd \"$(dirname \"$0\")\" && pwd)\"\n");
+        return sb.toString();
+    }
+
     private String genOptionsString() {
         StringBuilder sb = new StringBuilder();
         sb.append("# Translate options to tuple assignments").append("\n");
@@ -342,7 +369,9 @@ public class GenSh {
 
     private String genInvocation() {
         StringBuilder sb = new StringBuilder("# Invocation\n");
-        sb.append("java -jar ")
+        sb.append("java -Dublu.includepath=\"")
+                .append(includePath)
+                .append("\" -jar ")
                 .append(fqJarPath)
                 .append(' ')
                 .append("${gensh_runtime_opts} ")
@@ -372,6 +401,7 @@ public class GenSh {
                 .append(genSuperfluousArgumentWarning())
                 .append("\n")
                 .append(genOptionsString()).append("\n")
+                .append(genScriptDir()).append("\n")
                 .append(genInvocation())
                 .append("\nexit $?\n");
         return sb.toString();

--- a/src/ublu/util/JavaCallHelper.java
+++ b/src/ublu/util/JavaCallHelper.java
@@ -62,6 +62,8 @@ public class JavaCallHelper {
      * @param methodName The method name to find.
      * @param args The classes of the argument list.
      * @return the found method
+     * @throws NoSuchMethodException if the method could not be found matching any argument superclass combination
+     * @author Taylor C. Richberger
      */
     public static Method FindMethod(Class obj, String methodName, Class[] args) throws NoSuchMethodException {
         try {
@@ -103,6 +105,11 @@ public class JavaCallHelper {
      *
      * This method checks the cache first, then calls the recursive FindMethod
      * if the cache check misses.
+     * @param obj The class of the object to find the method for.
+     * @param methodName The method name to find.
+     * @param args The classes of the argument list.
+     * @return the found method
+     * @throws NoSuchMethodException if the method could not be found matching any argument superclass combination
      */
     public static Method GetMethod(Class obj, String methodName, Class[] args) throws NoSuchMethodException {
         // First check the cache for a call with the same class, argument classes, and method name
@@ -143,6 +150,9 @@ public class JavaCallHelper {
      * @throws NoSuchMethodException
      */
     public JavaCallHelper(Object o, String methodName, MethodArgPairList margs) throws NoSuchMethodException {
+        // TCR note: GetMethod is used as a level of indirection to facilitate
+        // a conditional "search cache or do a deep search for matching method"
+        // method finder
         this(o, GetMethod(o.getClass(), methodName, margs.toClassArray()), margs.toArgList());
         this.margs = margs;
     }
@@ -334,6 +344,9 @@ public class JavaCallHelper {
 
     /**
      * Class for use as a hash key, for the method cache.
+     *
+     * Essentially just a simple struct with some overrides to facilitate use
+     * as a HashMap key.
      */
     private static class MethodKey {
         private Class object;

--- a/src/ublu/util/Props.java
+++ b/src/ublu/util/Props.java
@@ -50,6 +50,13 @@ public class Props {
     public Props() {
         myProperties = new Properties();
         String includepath = System.getProperty("ublu.includepath", "");
+        String envincludepath = System.getenv("UBLU_INCLUDEPATH");
+        if (envincludepath != null && !envincludepath.isEmpty()) {
+            if (!includepath.isEmpty()) {
+                includepath += ':';
+            }
+            includepath += envincludepath;
+        }
         myProperties.setProperty("ublu.includepath", includepath.replace(";", ":"));
     }
 

--- a/src/ublu/util/Props.java
+++ b/src/ublu/util/Props.java
@@ -49,6 +49,8 @@ public class Props {
      */
     public Props() {
         myProperties = new Properties();
+        String includepath = System.getProperty("ublu.includepath", "");
+        myProperties.setProperty("ublu.includepath", includepath.replace(";", ":"));
     }
 
     /**

--- a/src/ublu/util/Props.java
+++ b/src/ublu/util/Props.java
@@ -49,6 +49,9 @@ public class Props {
      */
     public Props() {
         myProperties = new Properties();
+
+        // Set ublu.includepath based on system property and environment
+        // variable, combined in order
         String includepath = System.getProperty("ublu.includepath", "");
         String envincludepath = System.getenv("UBLU_INCLUDEPATH");
         if (envincludepath != null && !envincludepath.isEmpty()) {

--- a/userdoc/ubluref.html
+++ b/userdoc/ubluref.html
@@ -5320,7 +5320,7 @@ Type help for help. Type license for license. Type bye to exit.
 
   <blockquote>
     <tt>/5+ [-to datasink] [-strictPosix] [[-path
-    fullyqualifiedjarpath] [-opt optchar assignment_name tuplename
+    fullyqualifiedjarpath] [-includepath searchpath] [-opt optchar assignment_name tuplename
     ${ description }$ ..] [-optr optchar assignment_name tuplename
     ${ description }$] [-optx optchar multiple_assignment_name
     tuplename ${ description }$ ..]] ~@${scriptname}
@@ -5355,6 +5355,11 @@ Type help for help. Type license for license. Type bye to exit.
     <ul>
       <li><code>-strictPosix</code> means the script will follow
       Posix standards for function declarations.</li>
+      <li><code>-includepath</code> may be used to set a search path for the
+        script (and all modules), primarily so that gensh scripts can be used
+        portably.  $SCRIPTDIR is an available variable for embedding, and will
+        be set to the gensh script's directory on call.
+      </li>
 
       <li><tt>-opt optchar assignment_name tuplename ${ description
       }$</tt> creates in the generated script a

--- a/userdoc/ubluref.html
+++ b/userdoc/ubluref.html
@@ -5357,8 +5357,8 @@ Type help for help. Type license for license. Type bye to exit.
       Posix standards for function declarations.</li>
       <li><code>-includepath</code> may be used to set a search path for the
         script (and all modules), primarily so that gensh scripts can be used
-        portably.  $SCRIPTDIR is an available variable for embedding, and will
-        be set to the gensh script's directory on call.
+        portably.  <code>$SCRIPTDIR</code> is an available variable for
+        embedding, and will be set to the gensh script's directory on call.
       </li>
 
       <li><tt>-opt optchar assignment_name tuplename ${ description

--- a/userdoc/ubluref.html
+++ b/userdoc/ubluref.html
@@ -5345,7 +5345,7 @@ Type help for help. Type license for license. Type bye to exit.
 
   <blockquote>
     <tt>/5+ [-to datasink] [-strictPosix] [[-path
-    fullyqualifiedjarpath] [-includepath searchpath] [-opt optchar assignment_name tuplename
+    fullyqualifiedjarpath] [-includepath ~@${searchpath}] [-opt optchar assignment_name tuplename
     ${ description }$ ..] [-optr optchar assignment_name tuplename
     ${ description }$] [-optx optchar multiple_assignment_name
     tuplename ${ description }$ ..]] ~@${scriptname}
@@ -5384,6 +5384,8 @@ Type help for help. Type license for license. Type bye to exit.
         script (and all modules), primarily so that gensh scripts can be used
         portably.  <code>$SCRIPTDIR</code> is an available variable for
         embedding, and will be set to the gensh script's directory on call.
+        Check for the relative include description in <a
+        href="#include">include</a> for more information on how to use this.
       </li>
 
       <li><tt>-opt optchar assignment_name tuplename ${ description
@@ -6736,10 +6738,53 @@ Type help for help. Type license for license. Type bye to exit.
     remove the input line echo, a pipe to a grep filter can
     eliminate the input lines. e.g.:<br></p>
 
+
     <blockquote>
       <tt>java -jar ublu.jar include somefile.ublu | grep -v
       '^\:\:' &gt;output.txt</tt><br>
     </blockquote>
+
+    <p>Inclusion of an absolute filepath is done literally as written.
+    Relative paths are done with a special set of rules as follows:</p>
+
+    <ul>
+      <li>
+        The path is similarly defined to Unix shell paths, as a colon-separated
+        list (semicolon-separated is allowed for easier Windows compatibility,
+        but the semicolons are automatically converted to colons on load).
+        This search list lives in the ublu.includepath <a
+        href="#props">interpreter property</a>, which may be modified at
+        will.
+      </li>
+      <li>
+        On startup, Ublu checks the ublu.includepath system property. If set
+        and non-empty, the ublu.includepath interpreter property is copied from
+        it.
+      </li>
+      <li>
+        On startup, Ublu checks the UBLU_INCLUDEPATH environment variable. If
+        set and non-empty, the ublu.includepath interpreter property is copied
+        from it (or appended to it, if the property is already set at this
+        point).
+      </li>
+      <li>
+        When include is called with a relative path, each element of the
+        ublu.includepath property will be searched for the file in order until
+        one is found (eg. if <code>include foo/bar.ublu</code> is called, and
+        the ublu.includepath property is <code>/A:/B:.</code>, the include will
+        be searched in order as /A/foo/bar.ublu, /B/foo/bar.ublu, and
+        ./foo/bar.ublu).
+      </li>
+      <li>
+        If the file was not found in the search path, the file will be
+        attempted to be located relative to the including file's location (eg.
+        if <code>include foo/bar.ublu</code> is called from /path/to/baz.ublu,
+        /path/to/foo/bar.ublu will be tried).
+      </li>
+      <li>
+        If the file could not be found anywhere, a FileNotFoundException will
+        be raised and the command fails.
+      </li>
   </blockquote>
 
   <h4><a name="jmx" id="jmx"></a> <tt>jmx</tt></h4>


### PR DESCRIPTION
Absolute imports will continue to operate as before.

* The path is similarly defined to Unix shell paths, as a colon-separated list (semicolon-separated will also be accepted, to allow for better Windows compatibility)
* On startup, Ublu will check the ublu.includepath system property.  If set and non-empty, the ublu.includepath property will be copied from it.
* On startup, Ublu will check the UBLU_INCLUDEPATH environment variable.  If set and non-empty, it will be appended to the ublu.includepath interpreter property (unless ublu.includepath is empty, in which case it will be copied).
* On calling include, the filename specified will be searched for in the ublu.includepath interpreter property directories in order until found.  If not found, the current file's location will be tried last as a compatibility with current behavior.  If not found, a FileNotFoundException will be raised.
* gensh will accept a new dash command, -includepath, for a custom include path to be passed into java with -Dublu.includepath.  A $SCRIPTDIR variable will be available for use inside the include path, for local relative inclusion without absolute path dependency, making gensh scripts properly portable.