### PR TITLE
add VEX file with vulnerabilities information to SBOM

### DIFF
--- a/SBOM_ublu_jwoehr_1988a27f29d5cb6785af4d7b06a84ba43f0a8466.vex.json
+++ b/SBOM_ublu_jwoehr_1988a27f29d5cb6785af4d7b06a84ba43f0a8466.vex.json
@@ -1,0 +1,262 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-bdc39ae9f92f862e5685a1c104b5460202533e6dcb7892421ceaab842b21e771",
+  "author": "Unknown Author",
+  "timestamp": "2024-10-07T16:51:42.568925+02:00",
+  "last_updated": "2024-10-07T16:51:43.051173+02:00",
+  "version": 21,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2020-13692"
+      },
+      "timestamp": "2024-10-07T16:51:42.568926+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-21724"
+      },
+      "timestamp": "2024-10-07T16:51:42.594078+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-26520"
+      },
+      "timestamp": "2024-10-07T16:51:42.619425+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.25"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-26520"
+      },
+      "timestamp": "2024-10-07T16:51:42.643779+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-31197"
+      },
+      "timestamp": "2024-10-07T16:51:42.6672+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.25"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-31197"
+      },
+      "timestamp": "2024-10-07T16:51:42.690515+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-31197"
+      },
+      "timestamp": "2024-10-07T16:51:42.714541+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.3.3"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-31197"
+      },
+      "timestamp": "2024-10-07T16:51:42.739907+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.3.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41946"
+      },
+      "timestamp": "2024-10-07T16:51:42.763534+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.25"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41946"
+      },
+      "timestamp": "2024-10-07T16:51:42.787067+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41946"
+      },
+      "timestamp": "2024-10-07T16:51:42.810867+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.3.3"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41946"
+      },
+      "timestamp": "2024-10-07T16:51:42.834523+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.3.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41946"
+      },
+      "timestamp": "2024-10-07T16:51:42.858704+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.4.1"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-41946"
+      },
+      "timestamp": "2024-10-07T16:51:42.88269+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:42.906877+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.25"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:42.930752+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.2.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:42.95484+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.3.3"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:42.978436+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.3.5"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:43.002817+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.4.1"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:43.026967+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.5.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-1597"
+      },
+      "timestamp": "2024-10-07T16:51:43.051176+02:00",
+      "products": [
+        {
+          "@id": "pkg:maven/org.postgresql/postgresql@42.5.1"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}


### PR DESCRIPTION
Dear project owners,
We are a group of researchers investigating the usefulness of augmenting Software Bills of Materials (SBOMs) with information about known vulnerabilities of third-party dependencies.

As claimed in previous interview-based studies, a major limitation—according to software practitioners—of existing SBOMs is the lack of information about known vulnerabilities.  For this reason, we would like to investigate how augmented SBOMs are received in open-source projects.

To this aim, we have identified popular open-source repositories on GitHub that provided SBOMs, statically detected vulnerabilities on their dependencies in the OSV database, and, based on its output, we have augmented your repository’s SBOM by leveraging the OpenVEX implementation of the Vulnerability Exploitability eXchange (VEX). 

The JSON file in this pull request consists of statements each indicating i) the software products (i.e., dependencies) that may be affected by a vulnerability. These are linked to the SBOM components through the @id field in their Persistent uniform resource locator (pURL); ii) a CVE affecting the product; iii) an impact status defined by VEX. By default, all statements have status `under_investigation` as it is not yet known whether these product versions are actually affected by the vulnerability. After investigating the vulnerability, further statuses can be `affected`, `not_affected`, `fixed`. It is possible to motivate the new status in a `justification` field (see https://www.cisa.gov/sites/default/files/publications/VEX_Status_Justification_Jun22.pdf for more information). 
 
We open this pull request containing a VEX file related to the SBOM of your project, and hope it will be considered. 
We would also like to hear your opinion on the usefulness (or not) of this information by answering a 3-minute anonymous survey:
https://ww2.unipark.de/uc/sbom/

Thanks in advance, and regards,
Davide Fucci (Blekinge Institute of Technology, Sweden) 
Simone Romano and Giuseppe Scaniello (University of Salerno, Italy),
Massimiliano Di Penta (University of Sannio, Italy)